### PR TITLE
Fixing issue with ldap.readTimeoutSecs when >= 2147484 (b/34946221)

### DIFF
--- a/src/com/google/enterprise/adaptor/ldap/LdapAdaptor.java
+++ b/src/com/google/enterprise/adaptor/ldap/LdapAdaptor.java
@@ -198,11 +198,16 @@ public class LdapAdaptor extends AbstractAdaptor {
       log.config("ldap.readTimeoutSecs set to default of 90 sec.");
     }
     try {
-      if (Long.parseLong(timeInSeconds) <= 0) {
-        throw new InvalidConfigurationException("invalid (too small) value for "
-            + "ldap.readTimeoutSecs: " + timeInSeconds + "");
+      // according to com.sun.jndi.ldap.connect.timeout documentation,
+      // An integer less than or equal to zero means to use the network
+      // protocol's (i.e., TCP's) timeout value.
+      if (Long.parseLong(timeInSeconds) > (Integer.MAX_VALUE / 1000)) {
+        log.warning("invalid (too big) value for ldap.readTimeoutSecs, "
+            + "it has been set to the maximum value.");
+        return Integer.MAX_VALUE;
+      } else {
+        return 1000L * Long.parseLong(timeInSeconds);
       }
-      return 1000L * Long.parseLong(timeInSeconds);
     } catch (NumberFormatException e) {
       throw new InvalidConfigurationException("invalid (non-numeric) value for "
           + "ldap.readTimeoutSecs: " + timeInSeconds + "");

--- a/test/com/google/enterprise/adaptor/ldap/LdapAdaptorTest.java
+++ b/test/com/google/enterprise/adaptor/ldap/LdapAdaptorTest.java
@@ -284,18 +284,29 @@ public class LdapAdaptorTest {
   }
 
   @Test
+  public void testFakeAdaptorInitOKWithCustomValue()
+      throws Exception {
+    final FakeAdaptor ldapAdaptor = new FakeAdaptor();
+    AccumulatingDocIdPusher pusher = new AccumulatingDocIdPusher();
+    Map<String, String> configEntries = defaultConfigEntries();
+    configEntries.put("ldap.readTimeoutSecs", "1");
+    pushGroupDefinitions(ldapAdaptor, configEntries, pusher,
+        /*fullPush=*/ true, /*init=*/ true);
+    configEntries.put("ldap.readTimeoutSecs", "-1");
+    pushGroupDefinitions(ldapAdaptor, configEntries, pusher,
+        /*fullPush=*/ true, /*init=*/ true);
+    configEntries.put("ldap.readTimeoutSecs",
+        Integer.toString(Integer.MAX_VALUE / 1000));
+    pushGroupDefinitions(ldapAdaptor, configEntries, pusher,
+        /*fullPush=*/ true, /*init=*/ true);
+  }
+
+  @Test
   public void testFakeAdaptorInitThrowsICEWhenReadTimeoutSecsInvalid()
       throws Exception {
     final FakeAdaptor ldapAdaptor = new FakeAdaptor();
     AccumulatingDocIdPusher pusher = new AccumulatingDocIdPusher();
     Map<String, String> configEntries = defaultConfigEntries();
-    configEntries.put("ldap.readTimeoutSecs", "-1");
-    try {
-      pushGroupDefinitions(ldapAdaptor, configEntries, pusher,
-          /*fullPush=*/ true, /*init=*/ true);
-    } catch (InvalidConfigurationException ice) {
-      assertTrue(ice.getMessage().startsWith("invalid (too small) value"));
-    }
     configEntries.put("ldap.readTimeoutSecs", "bogus");
     try {
       pushGroupDefinitions(ldapAdaptor, configEntries, pusher,
@@ -303,6 +314,10 @@ public class LdapAdaptorTest {
     } catch (InvalidConfigurationException ice) {
       assertTrue(ice.getMessage().startsWith("invalid (non-numeric) value"));
     }
+    configEntries.put("ldap.readTimeoutSecs",
+        Integer.toString((Integer.MAX_VALUE / 1000) + 1));
+    pushGroupDefinitions(ldapAdaptor, configEntries, pusher,
+          /*fullPush=*/ true, /*init=*/ true);
   }
 
   @Test


### PR DESCRIPTION
This is an Int value/1000 and do not accept value bigger than 2.147.483,647