### PR TITLE
Add compiler flags for Java 6 and 7.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 dist/
 logs/
 adaptor-config.properties
+build.properties
 cacerts.jks
 keys.jks
 adaptor.crt

--- a/build.properties.sample
+++ b/build.properties.sample
@@ -1,0 +1,12 @@
+##
+# These properties are specific to the individual's development environment.
+#
+
+# Default JDK 6 installation location for Mac OS X.
+# However Macs haven't shipped with Java 6 for years.
+jdk6.home = /System/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home
+
+# JDK 6 bootclasspath.
+build.bootclasspath = ${jdk6.home}/jre/lib/classes.jar\
+    :${jdk6.home}/jre/lib/jsse.jar\
+    :${jdk6.home}/jre/lib/jce.jar

--- a/build.xml
+++ b/build.xml
@@ -30,6 +30,12 @@
   <!-- If adaptor.version isn't set, simply use the current date. -->
   <property name="adaptor.suffix" value="-${DSTAMP}"/>
 
+  <!-- Load build environment specific properties. -->
+  <property file="build.properties"/>
+  <property name="compile.java.source" value="6"/>
+  <property name="compile.java.target" value="7"/>
+  <property name="compile.java.bootclasspath" value="${build.bootclasspath}"/>
+
   <path id="adaptor.build.classpath">
 <!--
     <fileset dir="${lib.dir}">
@@ -107,7 +113,9 @@ lib/plexi submodule or add the the command line argument
     <mkdir dir="${build-src.dir}"/>
 
     <javac srcdir="${src.dir}" destdir="${build-src.dir}" debug="true"
-      includeantruntime="false" encoding="utf-8">
+      includeantruntime="false" encoding="utf-8"
+      source="${compile.java.source}" target="${compile.java.target}">
+      <bootclasspath path="${compile.java.bootclasspath}"/>
       <compilerarg value="-Xlint:unchecked"/>
       <classpath refid="adaptor.build.classpath"/>
     </javac>
@@ -115,7 +123,9 @@ lib/plexi submodule or add the the command line argument
     <mkdir dir="${build-test.dir}"/>
     <!-- Compile JUnit helper -->
     <javac srcdir="${lib.dir}" destdir="${build-test.dir}" debug="true"
-      includeantruntime="true" encoding="utf-8">
+      includeantruntime="true" encoding="utf-8"
+      source="${compile.java.source}" target="${compile.java.target}">
+      <bootclasspath path="${compile.java.bootclasspath}"/>
       <compilerarg value="-Xlint:unchecked"/>
       <classpath location="${junit.jar}"/>
       <include name="JUnitLogFixFormatter.java"/>
@@ -123,7 +133,9 @@ lib/plexi submodule or add the the command line argument
 
     <!-- Compile tests, excluding example tests. -->
     <javac srcdir="${test.dir}" destdir="${build-test.dir}" debug="true"
-      includeantruntime="false" encoding="utf-8">
+      includeantruntime="false" encoding="utf-8"
+      source="${compile.java.source}" target="${compile.java.target}">
+      <bootclasspath path="${compile.java.bootclasspath}"/>
       <compilerarg value="-Xlint:unchecked"/>
       <classpath refid="adaptor.build.classpath"/>
       <classpath location="${build-src.dir}"/>


### PR DESCRIPTION
Use source and bootclasspath for Java 6, but target Java 7.
This ensures source compatibility with Java 6, but avoids customers
running with Java 6 in production, which is not supported.

Use build.properties file for developer-specific build.bootclasspath
property.