### PR TITLE
I will run the unit tests when making trivial changes.

### DIFF
--- a/src/com/google/enterprise/adaptor/ldap/LdapServer.java
+++ b/src/com/google/enterprise/adaptor/ldap/LdapServer.java
@@ -393,7 +393,11 @@ class LdapServer {
     } else if (results.size() == 1) {
       LdapPerson person = results.iterator().next();
       log.exiting("LdapServer", "fetchOne", person);
-      return person;
+      if (person == null) {
+        throw new NullPointerException("Null LdapPerson found at " + dn);
+      } else {
+        return person;
+      }
     } else {
       log.exiting("LdapServer", "fetchOne", 2);
       throw new IllegalArgumentException("More than one person found at "

--- a/test/com/google/enterprise/adaptor/ldap/LdapServerTest.java
+++ b/test/com/google/enterprise/adaptor/ldap/LdapServerTest.java
@@ -556,17 +556,13 @@ public class LdapServerTest {
       }
     };
 
-    try {
-      LdapPerson fetched = ldapServer.fetchOne("ou=basedn");
-      fail("Did not catch expected IllegalArgumentException.");
-    } catch (IllegalArgumentException e) {
-      assertTrue(e.getMessage().contains("More than one person found"));
-    }
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("More than one person found at ou=basedn");
+    LdapPerson fetched = ldapServer.fetchOne("ou=basedn");
   }
 
   @Test
-  public void testFetchOneNonLdapPersonResult() throws Exception {
-    thrown.expect(NullPointerException.class);
+  public void testFetchOneNullLdapPersonResult() throws Exception {
     MockLdapContext ldapContext = new MockLdapContext();
     LdapServer ldapServer = new LdapServer("localhost", "nickname", "ou=basedn",
         "userFilter", "attr1,cn,dn" /* attributes */,
@@ -579,6 +575,8 @@ public class LdapServerTest {
       }
     };
 
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("Null LdapPerson found at ou=basedn");
     LdapPerson fetched = ldapServer.fetchOne("ou=basedn");
   }
 


### PR DESCRIPTION
Followup for commit ad64ffd. The code in LdapServer.fetchOne was
checking whether the single element in a Set<LdapPerson> was an
LdapPerson, and trying to throw an IllegalArgumentException if it
wasn't. <Object> instanceof LdapPerson fails on null, but the null was
deferenced trying to construct the IllegalArgumentException, so a
NullPointerException was thrown instead, as "verified" by a unit test.
I have preserved the actual NPE instead of the intended IAE.

Clean up two tests to use ExpectedException more often and better.